### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# ignore HTML files used for testing crawler
+tests/html-files/* linguist-vendored


### PR DESCRIPTION
We have a lot of HTML files which downloaded and used for testing crawling functionality instead of having to rely on making network requests to live systems. Some of these HTML files are very large and have caused the github to label the project as a HTML based one instead of a python based one.

This commit adds a .gitattributes file which uses githubs linguist[1], the library used by github to detect languages, to make sure all the test files are ignored by github.

[1]https://github.com/github/linguist