### PR TITLE
CI: split checks

### DIFF
--- a/.github/workflows/simple-ci.yml
+++ b/.github/workflows/simple-ci.yml
@@ -6,7 +6,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the "master" branch
   push:
-    branches: [ "**" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/simple-ci.yml
+++ b/.github/workflows/simple-ci.yml
@@ -15,8 +15,9 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+
+  pylint:
+
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -26,5 +27,31 @@ jobs:
       - uses: actions/checkout@v3
 
       # Runs a single command using the runners shell
-      - name: Run make check
-        run: make check
+      - name: Run pylint
+        run: make check-pylint-main
+
+  pycodestyle:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Runs a single command using the runners shell
+      - name: Run pycodestyle
+        run: make check-pycodestyle
+
+  pytests:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Runs a single command using the runners shell
+      - name: Run tests
+        run: make check-tests

--- a/.github/workflows/simple-ci.yml
+++ b/.github/workflows/simple-ci.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "**" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Currently, our CI runs `make check` which bundles all of our checks together. Although, this check makes local development easier (running one command) it can also be a pain in the bum when CI fails and you have to manually investigate exactly which check failed.

This commit runs each check separately so its easy to see exactly what has failed in the github actions tab without needing further investigation.