### PR TITLE
crawl/_api.py: ensure any spaces betweent metadata has dashes

### DIFF
--- a/crawl/_api.py
+++ b/crawl/_api.py
@@ -192,7 +192,7 @@ def process(course_data, dry_run=False):
                 meta_data = (
                     f"{course_data['course']}/{level['level']}/"
                     f"{module['module']}"
-                ).strip()
+                ).strip().replace(" ", "-")
                 yield construct_search_result_object(
                     topic.strip(), list(results), meta_data)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,13 +14,13 @@ FAKE_SET = {
 
 
 mock_curriculum_data = {
-    "course": "computer-science",
+    "course": "computer science",
     "levels": [
         {
-            "level": "university-year-1",
+            "level": "university year 1",
             "modules": [
                 {
-                    "module": "python-101",
+                    "module": "python 101",
                     "topics" : [
                         "IDLE Programming python",
                         "All About Strings python"


### PR DESCRIPTION
Currently, if a course name, level or module contains any spaces it gets translated as is when the path is created to save the topic list items. This is a pain to traverse because spaces need special character to escape them. Furthermore, it could lead to issues in some file systems that may not allow spaces in directory names.

This commit ensures that the meta data field in the search results object replaces any spaces with dashes.