### PR TITLE
sylli_crawl->driver_manager.py: use correct driver path in executable

### DIFF
--- a/sylli_crawl/utils/driver_manager.py
+++ b/sylli_crawl/utils/driver_manager.py
@@ -53,7 +53,7 @@ def get_driver(headless=True):
     try:
         driver = init_driver(
             options=options,
-            executable_path="sylli_crawl/phantomjs/geckodriver",
+            executable_path="sylli_crawl/geckodriver/geckodriver",
         )
         yield driver
 


### PR DESCRIPTION
This commit updates the driver executable path to the correct one (phantomjs has been removed).