### PR TITLE
syllime->crawlers: save any weird pages

### DIFF
--- a/sylli_crawl/html_crawler.py
+++ b/sylli_crawl/html_crawler.py
@@ -57,12 +57,22 @@ class HTMLCrawler(crawler_base.Crawler):
             helpers.write_error_urls(url)
 
         if resp:
-            title = self.parse_page(resp.text)
-            # add metadata
-            metadata["url"] = url
-            metadata["title"] = title
-            metadata["author"] = self.netloc
-            metadata["type"] = "A"
-            metadata["source"] = self.netloc
+            # temp solution till refactor
+            try:
+                title = self.parse_page(resp.text)
+                # add metadata
+                metadata["url"] = url
+                metadata["title"] = title
+                metadata["author"] = self.netloc
+                metadata["type"] = "A"
+                metadata["source"] = self.netloc
+            # we've received a weird page that we cant parse or something
+            # on the page has changed
+            except AttributeError as e:
+                logger.error(e)
+                # double check we actually have any source code
+                if resp:
+                    helpers.dump_pretty_html(
+                        BeautifulSoup(resp.text, 'lxml'), "html")
 
         return metadata

--- a/sylli_crawl/js_crawler.py
+++ b/sylli_crawl/js_crawler.py
@@ -308,9 +308,22 @@ class YoutubeCrawler(crawler_base.Crawler):
             return metadata
 
         if self.parsed_html and not self.has_captcha(self.parsed_html):
+            # temp solution till refactor
+            try:
+                title = self._video_title(self.parsed_html)
+                channel_name = self._channel_name(self.parsed_html)
+            # we've received a weird page that we cant parse or something
+            # on the page has changed
+            except AttributeError as e:
+                logger.error(e)
+                # double check we actually have any source code
+                if self.parsed_html:
+                    helpers.dump_pretty_html(self.parsed_html, "youtube")
+
+                return metadata
             metadata["url"] = url
-            metadata["title"] = self._video_title(self.parsed_html)
-            metadata["author"] = self._channel_name(self.parsed_html)
+            metadata["title"] = title
+            metadata["author"] = channel_name
             metadata["type"] = "V"
             metadata["source"] = f"{self.scheme}://{self.netloc}"
 


### PR DESCRIPTION
We've seen attribute errors in prod when a page is malformed (i.e. weird).

This commit catches that error and attempts to save the page html so we can investigate/update our tests to account for the weirdness.